### PR TITLE
do not auto-run the hashicups-<env> workspaces

### DIFF
--- a/setup/terraform/tfc-workspaces/main.tf
+++ b/setup/terraform/tfc-workspaces/main.tf
@@ -12,6 +12,7 @@ resource "tfe_workspace" "hashicups_prod" {
   name         = "hashicups-prod"
   organization = var.TFC_ORGANIZATION
   auto_apply = false
+  queue_all_runs = false
   terraform_version = "0.14.9"
   vcs_repo {
     identifier = "hashicups-development-team/hashicups-application"
@@ -24,6 +25,7 @@ resource "tfe_workspace" "hashicups_stage" {
   name         = "hashicups-staging"
   organization = var.TFC_ORGANIZATION
   auto_apply = false
+  queue_all_runs = false
   terraform_version = "0.14.9"
   vcs_repo {
     identifier = "hashicups-development-team/hashicups-application"
@@ -36,6 +38,7 @@ resource "tfe_workspace" "hashicups_dev" {
   name         = "hashicups-dev"
   organization = var.TFC_ORGANIZATION
   auto_apply = true
+  queue_all_runs = false
   terraform_version = "0.14.9"
   vcs_repo {
     identifier = "hashicups-development-team/hashicups-application"


### PR DESCRIPTION
Adding `queue_all_runs = false` to the hashicups-<env> workspaces created with the TFE provider to stop initial runs from being triggered since in Terraform 0.14.x, a timing issue sometimes causes the runs to be triggered before the variables have been set on the workspaces.  This means that the SE giving the demo will have to manually trigger runs for these workspaces before PRs done in GitLab will trigger runs.  I've added a note to the assignment for that.