### PR TITLE
create workspace after modules added to PMR

### DIFF
--- a/setup/terraform/tfc-registry/main.tf
+++ b/setup/terraform/tfc-registry/main.tf
@@ -35,6 +35,8 @@ resource "tfe_workspace" "workspace" {
     identifier = "hashicups-development-team/hashicups-application-module"
     oauth_token_id = var.OAUTH_TOKEN_ID
   }
+
+  depends_on = ["tfe_registry_module.rds-registry-module", "tfe_registry_module.server-registry-module"]
 }
 
 resource "tfe_variable" "aws_access_key" {


### PR DESCRIPTION
Make the tfe_workspace.workspace resource depend on the 3 tfe_registry_module resources so that when the first run is triggered for the workspace, the modules will definitely be in the PMR.  This mostly matters for testing with `instruqt track test` which is used by CircleCI.