### PR TITLE
don't run hashicups-module ws right away

### DIFF
--- a/setup/terraform/tfc-registry/main.tf
+++ b/setup/terraform/tfc-registry/main.tf
@@ -30,6 +30,7 @@ resource "tfe_workspace" "workspace" {
   name = "hashicups-module"
   organization = var.TFC_ORGANIZATION
   auto_apply = false
+  queue_all_runs = false
   terraform_version = "0.14.9"
 
   vcs_repo {


### PR DESCRIPTION
running right away can fail since AWS env vars might not yet be set