### PR TITLE
add require-all-resources-from-pmr policy

### DIFF
--- a/gitclones/sentinel-policies/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules/sentinel.hcl
+++ b/gitclones/sentinel-policies/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules/sentinel.hcl
@@ -1,3 +1,3 @@
 policy "aws-cis-4.1-networking-deny-public-ssh-acl-rules" {
-  enforcement_level = "hard-mandatory"
+  enforcement_level = "soft-mandatory"
 }

--- a/gitclones/sentinel-policies/cloud-agnostic/pmr/require-all-resources-from-pmr.sentinel
+++ b/gitclones/sentinel-policies/cloud-agnostic/pmr/require-all-resources-from-pmr.sentinel
@@ -1,0 +1,49 @@
+# This policy uses the tfconfig/v2 import to require that all non-root
+# modules come from the Private Module Registry and that no resources
+# or data sources are created in the root module.
+
+# Import the tfconfig/v2 import, but use the alias "tfconfig"
+import "tfconfig/v2" as tfconfig
+
+# Standard strings import
+import "strings"
+
+### Parameters ###
+# The address of the TFC or TFE server
+param address default "app.terraform.io"
+# The organization on the TFC or TFE server
+param organization
+
+# Fnd modules called from root module that are not in the desired PMR
+violatingMCs = filter tfconfig.module_calls as index, mc {
+  mc.module_address is "" and
+  not strings.has_prefix(mc.source, address + "/" + organization)
+}
+
+# Print violation messages for invalid modules
+if length(violatingMCs) > 0 {
+  print("All modules called from the root module must come from the",
+        "private module registry", address + "/" + organization)
+  for violatingMCs as address, mc {
+    print("The module", mc.name, "called from the root module has source",
+          mc.source)
+  }
+}
+
+# Find resources and data sources in root module
+rootModuleResources = filter tfconfig.resources as address, r {
+  r.module_address is ""
+}
+
+# Print violation messages for root module resources and data sources
+if length(rootModuleResources) > 0 {
+  print("Resources and data sources are not allowed in the root module.")
+  print("Your root module has", length(rootModuleResources), "resources and",
+        "data sources.")
+}
+
+# Main rule
+validated = length(violatingMCs) is 0 and length(rootModuleResources) is 0
+main = rule {
+ validated is true
+}

--- a/gitclones/sentinel-policies/cloud-agnostic/pmr/sentinel.hcl
+++ b/gitclones/sentinel-policies/cloud-agnostic/pmr/sentinel.hcl
@@ -1,0 +1,4 @@
+policy "require-all-resources-from-pmr" {
+    source = "./require-all-resources-from-pmr.sentinel"
+    enforcement_level = "soft-mandatory"
+}

--- a/setup/terraform/tfc-sentinel/main.tf
+++ b/setup/terraform/tfc-sentinel/main.tf
@@ -1,8 +1,8 @@
-resource "tfe_policy_set" "awsssh" {
-  name          = "CIS-Benchmarks-4_1-Networking"
-  description   = "CIS Benchmarks 4.1"
+resource "tfe_policy_set" "pmr" {
+  name          = "require-all-resources-from-pmr"
+  description   = "Requires all non-root modules come from the private module registry and prevents creation of resources in the root module"
   organization  = var.TFC_ORGANIZATION
-  policies_path = "/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules"
+  policies_path = "/cloud-agnostic/pmr"
   global = true
 
   vcs_repo {


### PR DESCRIPTION
adds require-all-resources-from-pmr.sentinel policy
the CIS networking AWS policy can still be added manually. Note that the assignment actually gave the user steps to deploy it even though it had already been added by Terraform OSS in the tfc-sentinel project.

Focusing on the require-all-resources-from-pmr.sentinel policy gives more continuity in the track after the PMR challenge.