### PR TITLE
improve Sentinel policies

### DIFF
--- a/gitclones/sentinel-policies/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules/aws-cis-4.1-networking-deny-public-ssh-acl-rules.sentinel
+++ b/gitclones/sentinel-policies/aws/networking/aws-cis-4.1-networking-deny-public-ssh-acl-rules/aws-cis-4.1-networking-deny-public-ssh-acl-rules.sentinel
@@ -1,19 +1,19 @@
 import "tfplan/v2" as tfplan
 
 aws_security_groups = filter tfplan.resource_changes as _, resource_changes {
-	length(resource_changes.change.after.ingress else []) != 0 and
-		resource_changes.mode is "managed" and
+	resource_changes.mode is "managed" and
 		resource_changes.type is "aws_security_group" and
 		(resource_changes.change.actions contains "create" or
-			resource_changes.change.actions is ["update"])
+			resource_changes.change.actions is ["update"]) and
+		length(resource_changes.change.after.ingress else []) != 0
 }
 
 aws_security_group_rules = filter tfplan.resource_changes as _, resource_changes {
 	resource_changes.mode is "managed" and
 		resource_changes.type is "aws_security_group_rule" and
-		resource_changes.change.after.type is "ingress" and
 		(resource_changes.change.actions contains "create" or
-			resource_changes.change.actions is ["update"])
+			resource_changes.change.actions is ["update"]) and
+		resource_changes.change.after.type is "ingress"
 }
 
 ssh_security_groups = filter aws_security_groups as _, asg {

--- a/gitclones/sentinel-policies/aws/networking/aws-cis-4.2-networking-deny-public-rdp-acl-rules/aws-cis-4.2-networking-deny-public-rdp-acl-rules.sentinel
+++ b/gitclones/sentinel-policies/aws/networking/aws-cis-4.2-networking-deny-public-rdp-acl-rules/aws-cis-4.2-networking-deny-public-rdp-acl-rules.sentinel
@@ -1,19 +1,19 @@
 import "tfplan/v2" as tfplan
 
 aws_security_groups = filter tfplan.resource_changes as _, resource_changes {
-	length(resource_changes.change.after.ingress else []) != 0 and
-		resource_changes.mode is "managed" and
+	resource_changes.mode is "managed" and
 		resource_changes.type is "aws_security_group" and
 		(resource_changes.change.actions contains "create" or
-			resource_changes.change.actions is ["update"])
+			resource_changes.change.actions is ["update"]) and
+		length(resource_changes.change.after.ingress else []) != 0
 }
 
 aws_security_group_rules = filter tfplan.resource_changes as _, resource_changes {
 	resource_changes.mode is "managed" and
 		resource_changes.type is "aws_security_group_rule" and
-		resource_changes.change.after.type is "ingress" and
 		(resource_changes.change.actions contains "create" or
-			resource_changes.change.actions is ["update"])
+			resource_changes.change.actions is ["update"]) and
+		resource_changes.change.after.type is "ingress"
 }
 
 rdp_security_groups = filter aws_security_groups as _, asg {

--- a/gitclones/sentinel-policies/cloud-agnostic/pmr/require-all-resources-from-pmr.sentinel
+++ b/gitclones/sentinel-policies/cloud-agnostic/pmr/require-all-resources-from-pmr.sentinel
@@ -24,7 +24,7 @@ violatingMCs = filter tfconfig.module_calls as index, mc {
 }
 
 # Print violation messages for invalid modules
-if length(violatingMCs) > 0 {
+if length(violatingMCs) > 0 and not tfrun.is_destroy {
   print("All modules called from the root module must come from the",
         "private module registry", address + "/" + organization)
   for violatingMCs as address, mc {
@@ -39,14 +39,16 @@ rootModuleResources = filter tfconfig.resources as address, r {
 }
 
 # Print violation messages for root module resources and data sources
-if length(rootModuleResources) > 0 {
+if length(rootModuleResources) > 0 and not tfrun.is_destroy {
   print("Resources and data sources are not allowed in the root module.")
   print("Your root module has", length(rootModuleResources), "resources and",
         "data sources.")
 }
 
 # Main rule
-validated = length(violatingMCs) is 0 and length(rootModuleResources) is 0
+validated = tfrun.is_destroy or
+            (length(violatingMCs) is 0 and
+            length(rootModuleResources) is 0)
 main = rule {
  validated is true
 }


### PR DESCRIPTION
Improve 3 Sentinel policies to better handle destroys
The fixes for two CIS policies avoid hard failure due to evaluation of selector against null.
The fix for the PMR policy prevents failure when destroy is being done.