### PR TITLE
Remove deprecated in favour of templatefile()

### DIFF
--- a/gitclones/hashicups-application/terraform-aws-server/instances.tf
+++ b/gitclones/hashicups-application/terraform-aws-server/instances.tf
@@ -19,13 +19,6 @@ data "aws_ami" "ubuntu" {
   owners = ["099720109477"] # Canonical
 }
 
-data "template_file" "config" {
-  template = file("${path.module}/configs/${var.name}.tpl")
-  vars = {
-    upstream_ip = var.upstream_ip
-  }
-}
-
 resource "aws_instance" "instance" {
   instance_type               = "t2.small"
   ami                         = data.aws_ami.ubuntu.id
@@ -37,5 +30,5 @@ resource "aws_instance" "instance" {
   private_ip                  = var.private_ip
   tags                        = var.tags
 
-  user_data = data.template_file.config.rendered
+  user_data = templatefile("${path.module}/configs/${var.name}.tpl", { upstream_ip = var.upstream_ip })
 }

--- a/gitclones/terraform-aws-server-module/instances.tf
+++ b/gitclones/terraform-aws-server-module/instances.tf
@@ -19,13 +19,6 @@ data "aws_ami" "ubuntu" {
   owners = ["099720109477"] # Canonical
 }
 
-data "template_file" "config" {
-  template = file("${path.module}/configs/${var.name}.tpl")
-  vars = {
-    upstream_ip = var.upstream_ip
-  }
-}
-
 resource "aws_instance" "instance" {
   instance_type               = "t2.small"
   ami                         = data.aws_ami.ubuntu.id
@@ -36,6 +29,6 @@ resource "aws_instance" "instance" {
   iam_instance_profile        = aws_iam_instance_profile.instance.id
   private_ip                  = var.private_ip
   tags                        = var.tags
-
-  user_data = data.template_file.config.rendered
+  
+  user_data = templatefile("${path.module}/configs/${var.name}.tpl", { upstream_ip = var.upstream_ip })
 }

--- a/setup/terraform/tfc-workspaces/main.tf
+++ b/setup/terraform/tfc-workspaces/main.tf
@@ -15,7 +15,7 @@ resource "tfe_workspace" "hashicups_prod" {
   queue_all_runs = false
   terraform_version = "0.14.9"
   vcs_repo {
-    identifier = "hashicups-development-team/hashicups-application"
+    identifier = "hashicups-development-team/hashicups-application-module"
     branch = "master"
     oauth_token_id     = tfe_oauth_client.test-oauth-client.oauth_token_id
   }
@@ -28,7 +28,7 @@ resource "tfe_workspace" "hashicups_stage" {
   queue_all_runs = false
   terraform_version = "0.14.9"
   vcs_repo {
-    identifier = "hashicups-development-team/hashicups-application"
+    identifier = "hashicups-development-team/hashicups-application-module"
     branch = "stage"
     oauth_token_id     = tfe_oauth_client.test-oauth-client.oauth_token_id
   }
@@ -41,7 +41,7 @@ resource "tfe_workspace" "hashicups_dev" {
   queue_all_runs = false
   terraform_version = "0.14.9"
   vcs_repo {
-    identifier = "hashicups-development-team/hashicups-application"
+    identifier = "hashicups-development-team/hashicups-application-module"
     branch = "development"
     oauth_token_id     = tfe_oauth_client.test-oauth-client.oauth_token_id
   }


### PR DESCRIPTION
Working through the SE onboarding resources, I came across an error with `terraform init` with the use of the deprecated `template_file` for users on MacBook M1 laptops on Terraform version: `1.1.6`.

I figured this would smooth out the UX for a first-time SE doing the exercise.

Signed-off-by: acornies <andrew.cornies@hashicorp.com>